### PR TITLE
append current state path to port spec target and sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This plugin is intended to replicate the rebar2 support for compiling native
 code. It is not a drop-in replacement in terms of command-line interface but the
 exact configuration interface in projects' `rebar.config`s have been preserved.
 
-Use
----
+Use In Your Project
+---------------------
 
 Add the plugin to your `rebar.config`:
 
@@ -37,6 +37,35 @@ From your existing application:
     Compiling ...
 
 You should now have native code compiled.
+
+Use with Existing Dependency
+-----------------------------
+
+If your project depends on a dependency that used the rebar2 port compiler instead of forking and changing the `rebar.config` of that dependency you can use [overrides](http://www.rebar3.org/v3.0/docs/configuration#overrides) to inject the changes from your top level `rebar.config`. Using [jiffy](https://github.com/davisp/jiffy) as an example:
+
+
+```erlang
+{deps, [
+  {jiffy, {git, "git@github.com:davisp/jiffy.git", {branch, "master"}}}
+]}.
+
+{overrides,
+ [{override, jiffy, [
+     {plugins, [
+         {pc, {git, "git@github.com:blt/port_compiler.git", {branch, "master"}}}
+     ]},
+
+     {provider_hooks, [
+         {post,
+             [
+             {compile, {pc, compile}},
+             {clean, {pc, clean}}
+             ]
+          }]
+      }
+  ]}
+]}.
+```
 
 Example
 ---

--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -63,7 +63,7 @@ compile_and_link(State, Specs) ->
                       Cmd = expand_command(LinkTemplate, Env,
                                            string:join(Bins, " "),
                                            Target),
-                      rebar_utils:sh(Cmd, [{env, Env}]);
+                      rebar_utils:sh(Cmd, [{env, Env}, {cd, rebar_state:dir(State)}]);
                   false ->
                       ok
               end

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -87,10 +87,14 @@ get_port_spec(Config, OsType, {Target, Sources}) ->
 get_port_spec(Config, OsType, {Arch, Target, Sources}) ->
     get_port_spec(Config, OsType, {Arch, Target, Sources, []});
 get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
-    SourceFiles = lists:flatmap(fun filelib:wildcard/1, Sources),
+    SourceFiles = lists:flatmap(fun(Source) ->
+                                        Source1 = filename:join(rebar_state:dir(Config), Source),
+                                        filelib:wildcard(Source1)
+                                end, Sources),
+    Target1 = filename:join(rebar_state:dir(Config), Target),
     ObjectFiles = [pc_util:replace_extension(O, ".o") || O <- SourceFiles],
-    #spec{type    = pc_util:target_type(Target),
-          target  = coerce_extension(OsType, Target),
+    #spec{type    = pc_util:target_type(Target1),
+          target  = coerce_extension(OsType, Target1),
           sources = SourceFiles,
           objects = ObjectFiles,
           opts    = [port_opt(Config, O) || O <- fill_in_defaults(Opts)]}.

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -82,7 +82,7 @@ port_spec_from_legacy(Config) ->
     %% Get the list of source files from port_sources
     Sources = port_sources(rebar_state:get(Config, port_sources,
                                                  ["c_src/*.c"])),
-    #spec { type = target_type(Target),
+    #spec { type = pc_util:target_type(Target),
             target = maybe_switch_extension(os:type(), Target),
             sources = Sources,
             objects = port_objects(Sources),
@@ -91,20 +91,13 @@ port_spec_from_legacy(Config) ->
 port_sources(Sources) ->
     lists:flatmap(fun filelib:wildcard/1, Sources).
 
-target_type(Target) -> target_type1(filename:extension(Target)).
-
-target_type1(".so")  -> drv;
-target_type1(".dll") -> drv;
-target_type1("")     -> exe;
-target_type1(".exe") -> exe.
-
 maybe_switch_extension({win32, nt}, Target) ->
     switch_to_dll_or_exe(Target);
 maybe_switch_extension(_OsType, Target) ->
     Target.
 
 port_objects(SourceFiles) ->
-    [replace_extension(O, ".o") || O <- SourceFiles].
+    [pc_util:replace_extension(O, ".o") || O <- SourceFiles].
 
 filter_port_spec({ArchRegex, _, _, _}) ->
     rebar_utils:is_arch(ArchRegex);
@@ -112,13 +105,6 @@ filter_port_spec({ArchRegex, _, _}) ->
     rebar_utils:is_arch(ArchRegex);
 filter_port_spec({_, _}) ->
     true.
-
-replace_extension(File, NewExt) ->
-    OldExt = filename:extension(File),
-    replace_extension(File, OldExt, NewExt).
-
-replace_extension(File, OldExt, NewExt) ->
-    filename:rootname(File, OldExt) ++ NewExt.
 
 get_port_spec(Config, OsType, {Target, Sources}) ->
     get_port_spec(Config, OsType, {undefined, Target, Sources, []});


### PR DESCRIPTION
This is needed for running in a dep so the paths are correct.
