### PR TITLE
Don't depend on rebar3 dependencies; it overrides them

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,13 +21,3 @@
   deprecated_function_calls,
   deprecated_functions
  ]}.
-
-{deps, [
-       {providers, "",
-        {git, "https://github.com/tsloughter/providers.git",
-         {tag, "v1.3.1"}}}
-        %% TODO: I can't rightly run xref on this project without rebar, but
-        %% doesn't build as a dependency...
-        %% {rebar, {git, "git@github.com:rebar/rebar3.git",
-        %%          {branch, "master"}}}
-       ]}.


### PR DESCRIPTION
This blocks or prevents rebar3 from deploying bugfixes in providers when this plugin is used
