### PR TITLE
add hex metadata to app.src file

### DIFF
--- a/src/pc.app.src
+++ b/src/pc.app.src
@@ -1,7 +1,7 @@
 {application, pc,
  [
   {description, "a rebar3 port compiler for native code"},
-  {vsn, "0.1.0"},
+  {vsn, "0.2.0"},
   {registered, []},
   {applications,
    [
@@ -9,5 +9,9 @@
     stdlib
    ]},
   {env,[]},
-  {modules, []}
+  {modules, []},
+
+  {contributors, ["Brian L. Troutwine"]},
+  {licenses, ["MIT"]},
+  {links, [{"Github", "https://github.com/blt/port_compiler"}]}
  ]}.


### PR DESCRIPTION
You should then add `rebar3_hex` to `~/.config/rebar3/rebar.config` under `{plugins, []}.`, setup a hex account with `rebar3 hex user register` and publish with `publish` or `cut` http://www.rebar3.org/v3.0/docs/hex-package-management#user

When it is added to hex I want to add it to http://www.rebar3.org/v3.0/docs/using-available-plugins
