### PR TITLE
This should handle cases where .d files have unexpected leading whitespace

### DIFF
--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -178,10 +178,8 @@ bin_deps(Bin) ->
     end.
 
 parse_bin_deps(Bin, Deps) ->
-    Sz = size(Bin),
-    <<Bin:Sz/binary, ": ", X/binary>> = Deps,
-    Ds = re:split(X, "\\s*\\\\\\R\\s*|\\s+", [{return, binary}]),
-    [D || D <- Ds, D =/= <<>>].
+    Ds = re:split(Deps, "\\s*\\\\\\R\\s*|\\s+", [{return, binary}]),
+    [D || D <- Ds, D =/= <<>>, D =/= <<Bin/binary,":">>].
 
 %%
 %% == linking ==


### PR DESCRIPTION
This fixes a problem I encountered on CentOS 5, where the .d file had leading whitespace, both newlines and spaces. I decided to let the regex handle everything and then just filter our the `Bin`. Although maybe you'd like me to do validation that `Bin` is actually there?

Thanks.
