### PR TITLE
Don't do string ops on AppName which is a binary

### DIFF
--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -84,7 +84,8 @@ port_spec_from_legacy(Config) ->
                                       undefined ->
                                           throw({error, {pc_prv_compile, no_app}});
                                       CurrentApp ->
-                                          rebar_app_info:name(CurrentApp)
+                                          BAppName = rebar_app_info:name(CurrentApp),
+                                          binary_to_list(BAppName)
                                   end,
                      filename:join("priv", lists:concat([AppName, "_drv.so"]));
                  AName ->


### PR DESCRIPTION
This broke compilation in every case I tried, but it's OK after the fix. There's a number of ops later in the call chain which assume the parameters to be strings (specifically, `pc_util:replace_extension/2`).
