### PR TITLE
Expand env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ BELOW HERE BE DRAGONS
 %%                {ArchRegex, TargetFile, Sources}
 %%                {TargetFile, Sources}
 %%
+%%                Note that if you want to use any of the rebar3 variables
+%%                below you must MUST use a ${}-style to get the expansion
+%%                to work. e.g. to expand REBAR_DEPS_DIR, do something like:
+%%
+%%                {port_specs, [{"priv/nif.so",
+%%                               ["c_src/nif.c",
+%%                                "${REBAR_DEPS_DIR}/foo/bar.c"]}]}.
+%%
+%%                This is a _very_ good way to be able to use you code both
+%%                as a top level app and a dependency.
+%%
+%%                CAVEAT! Not using {} is broken for the moment.
+%%
 %% * port_env - Erlang list of key/value pairs which will control
 %%              the environment when running the compiler and linker.
 %%              Variables set in the surrounding system shell are taken

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ BELOW HERE BE DRAGONS
 %%                               ["c_src/nif.c",
 %%                                "${REBAR_DEPS_DIR}/foo/bar.c"]}]}.
 %%
-%%                This is a _very_ good way to be able to use you code both
+%%                This is a _very_ good way to be able to use your code both
 %%                as a top level app and a dependency.
 %%
 %%                CAVEAT! Not using {} is broken for the moment.

--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -60,7 +60,7 @@ compile_and_link(State, Specs) ->
                   true ->
                       LinkLang = pc_port_specs:link_lang(Spec),
                       LinkTemplate = select_link_template(LinkLang, Target),
-                      Env = pc_port_specs:environment(Spec),
+                      Env = pc_port_specs:environment(Spec, State),
                       Cmd = expand_command(LinkTemplate, Env,
                                            pc_util:strjoin(Bins, " "),
                                            Target),
@@ -91,18 +91,18 @@ port_deps(SourceFiles) ->
 %% == compilation ==
 %%
 
-compile_sources(Config, Specs) ->
+compile_sources(State, Specs) ->
     {NewBins, Db} =
         lists:foldl(
           fun(Spec, Acc) ->
                   Sources = pc_port_specs:sources(Spec),
                   Type    = pc_port_specs:type(Spec),
-                  Env     = pc_port_specs:environment(Spec),
-                  compile_each(Config, Sources, Type, Env, Acc)
+                  Env     = pc_port_specs:environment(Spec, State),
+                  compile_each(State, Sources, Type, Env, Acc)
           end, {[], []}, Specs),
     %% Rewrite clang compile commands database file only if something
     %% was compiled.
-    case {NewBins, rebar_state:get(Config, pc_clang_db, false)} of
+    case {NewBins, rebar_state:get(State, pc_clang_db, false)} of
         {[], _} ->
             ok;
         {_, true} ->

--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -60,7 +60,7 @@ compile_and_link(State, Specs) ->
                   true ->
                       LinkLang = pc_port_specs:link_lang(Spec),
                       LinkTemplate = select_link_template(LinkLang, Target),
-                      Env = pc_port_specs:environment(Spec, State),
+                      Env = pc_port_specs:create_env(State, Spec),
                       Cmd = expand_command(LinkTemplate, Env,
                                            pc_util:strjoin(Bins, " "),
                                            Target),
@@ -91,18 +91,18 @@ port_deps(SourceFiles) ->
 %% == compilation ==
 %%
 
-compile_sources(State, Specs) ->
+compile_sources(Config, Specs) ->
     {NewBins, Db} =
         lists:foldl(
           fun(Spec, Acc) ->
                   Sources = pc_port_specs:sources(Spec),
                   Type    = pc_port_specs:type(Spec),
-                  Env     = pc_port_specs:environment(Spec, State),
-                  compile_each(State, Sources, Type, Env, Acc)
+                  Env     = pc_port_specs:create_env(Config, Spec),
+                  compile_each(Config, Sources, Type, Env, Acc)
           end, {[], []}, Specs),
     %% Rewrite clang compile commands database file only if something
     %% was compiled.
-    case {NewBins, rebar_state:get(State, pc_clang_db, false)} of
+    case {NewBins, rebar_state:get(Config, pc_clang_db, false)} of
         {[], _} ->
             ok;
         {_, true} ->

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -145,13 +145,19 @@ get_port_spec(Config, OsType, {Target, Sources}) ->
 get_port_spec(Config, OsType, {Arch, Target, Sources}) ->
     get_port_spec(Config, OsType, {Arch, Target, Sources, []});
 get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
+    Env = rebar_state:env(Config),
     SourceFiles =
         lists:flatmap(
           fun(Source) ->
-                  Source1 = rebar_utils:escape_chars(
-                              filename:join(rebar_state:dir(Config), Source)),
+                  Source1 =
+                      lists:foldl(
+                        fun({Key, Value}, Acc) ->
+                                rebar_utils:expand_env_variable(Acc, Key, Value)
+                        end, Source, Env),
+                  Source2 = rebar_utils:escape_chars(
+                              filename:join(rebar_state:dir(Config), Source1)),
                   case filelib:wildcard(Source1) of
-                      [] -> [Source1];
+                      [] -> [Source2];
                       FileList -> FileList
                   end
           end, Sources),

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -32,6 +32,7 @@
          construct/1,
          %% spec accessors
          environment/1,
+         environment/2,
          objects/1,
          sources/1,
          target/1,
@@ -69,6 +70,9 @@ construct(State) ->
 %% == Spec Accessors ==
 
 environment(#spec{opts = Opts})        -> proplists:get_value(env, Opts).
+environment(#spec{opts = Opts}, State) ->
+    proplists:get_value(env, Opts) ++
+        try_and_get_env(State).
 objects(#spec{objects = Objects})      -> Objects.
 sources(#spec{sources = Sources})      -> Sources.
 target(#spec{target = Target})         -> Target.
@@ -78,6 +82,14 @@ link_lang(#spec{link_lang = LinkLang}) -> LinkLang.
 %%%===================================================================
 %%% Internal Functions
 %%%===================================================================
+
+try_and_get_env(State) ->
+    case catch rebar_state:env(State) of
+        {'EXIT', _} ->
+            [];
+        Env ->
+            Env
+    end.
 
 port_spec_from_legacy(Config) ->
     %% Get the target from the so_name variable

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -184,6 +184,10 @@ expand_env(Source, Env) ->
         _ ->
             lists:foldl(
               fun({Key, Value}, Acc) ->
+                      %% TODO: the expand_env_variable/3 only expands
+                      %% variables delimited by whitespace and inside
+                      %% ${}. Either fix or add a new function to
+                      %% rebar3 or make a new function here in pc.
                       rebar_utils:expand_env_variable(Acc, Key, Value)
               end, Source, Env)
     end.

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -69,9 +69,8 @@ construct(State) ->
     end.
 
 create_env(State, Spec) ->
-    Opts = rebar_state:opts(State),
     pc_port_specs:environment(Spec) ++
-        try_and_create_env(State, Opts).
+        try_and_create_env(State).
 
 %% == Spec Accessors ==
 
@@ -87,11 +86,11 @@ link_lang(#spec{link_lang = LinkLang}) -> LinkLang.
 %%% Internal Functions
 %%%===================================================================
 
-try_and_create_env(State, Opts) ->
+try_and_create_env(State) ->
     _ = code:ensure_loaded(rebar_env),
-    case erlang:function_exported(rebar_env, create_env, 2) of
+    case erlang:function_exported(rebar_env, create_env, 1) of
         false -> [];
-        true -> rebar_env:create_env(State, Opts)
+        true -> rebar_env:create_env(State)
     end.
 
 port_spec_from_legacy(Config) ->
@@ -148,8 +147,7 @@ get_port_spec(Config, OsType, {Target, Sources}) ->
 get_port_spec(Config, OsType, {Arch, Target, Sources}) ->
     get_port_spec(Config, OsType, {Arch, Target, Sources, []});
 get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
-    StateOpts = rebar_state:opts(Config),
-    Env = try_and_create_env(Config, StateOpts),
+    Env = try_and_create_env(Config),
     SourceFiles =
         lists:flatmap(
           fun(Source) ->


### PR DESCRIPTION
This fixes https://github.com/blt/port_compiler/issues/30 and lets both env variables be exported and you can now use env variables from rebar3 inside port_specs, as they are expanded while evaluating the port_specs.

It depends on https://github.com/erlang/rebar3/pull/1706 which in turn depends on https://github.com/erlang/rebar3/pull/1698 but it is written so it shouldn't crash if using an older rebar3. Please check that it doesn't crash for you, before merge:ing.

Also I have updated the README to reflect how to use the env variables inside port_specs cause it depends on how rebar3 exports variables. Specifically, it needs ${} expansion, but at least it works.

