### PR TITLE
Fix file wildcard issue

### DIFF
--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -128,8 +128,6 @@ maybe_report_wc(Source, Found) ->
     end,
     Found.
 
-wildcard(Source) ->
-    maybe_report_wc(Source, filelib:wildcard(Source)).
 wildcard(Source, WorkDir) ->
     maybe_report_wc(Source, filelib:wildcard(Source, WorkDir)).
 
@@ -162,7 +160,7 @@ get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
     SourceFiles =
         lists:flatmap(
           fun(Source) ->
-                  wildcard(expand_env(Source, Env))
+                  wildcard(expand_env(Source, Env), rebar_state:dir(Config))
           end, Sources),
     LinkLang =
         case lists:any(


### PR DESCRIPTION
On win32 the missing directory would lead to an incorrect list of input files. 