### PR TITLE
Fix waning when C/C++ files are compiled on Windows

### DIFF
--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -120,7 +120,7 @@ compile_each(_State, [], _Type, _Env, {NewBins, CDB}) ->
     {lists:reverse(NewBins), lists:reverse(CDB)};
 compile_each(State, [Source | Rest], Type, Env, {NewBins, CDB}) ->
     Ext = filename:extension(Source),
-    Bin = pc_util:replace_extension(Source, Ext, ".o"),
+    Bin = pc_util:replace_extension(Source, Ext, pc_port_specs:object_file_ext()),
     Template = select_compile_template(Type, compiler(Ext)),
     Cmd = expand_command(Template, Env, Source, Bin),
     CDBEnt = cdb_entry(State, Source, Cmd, Rest),

--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -38,7 +38,8 @@
          sources/1,
          target/1,
          type/1,
-         link_lang/1
+         link_lang/1,
+         object_file_ext/0
         ]).
 -export_type([spec/0]).
 
@@ -144,7 +145,8 @@ maybe_switch_extension(_OsType, Target) ->
     Target.
 
 port_objects(SourceFiles) ->
-    [pc_util:replace_extension(O, ".o") || O <- SourceFiles].
+    Ext = object_file_ext(),
+    [pc_util:replace_extension(O, Ext) || O <- SourceFiles].
 
 filter_port_spec({ArchRegex, _, _, _}) ->
     pc_util:is_arch(ArchRegex);
@@ -232,3 +234,9 @@ port_opt(State, {env, Env}) ->
     {env, PortEnv};
 port_opt(_State, Opt) ->
     Opt.
+
+object_file_ext() ->
+    case os:type() of
+        {win32,_} -> ".obj";
+        _         -> ".o"
+    end.


### PR DESCRIPTION
The fix warning text is similar to:
```
cl : Command line warning D9024 : unrecognized source file type 'c_src/xxx.o', object file assumed
```