### PR TITLE
link erl_interface when opt_release < 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ BELOW HERE BE DRAGONS
 %%              CXXFLAGS - C++ compiler
 %%              LDFLAGS  - Link flags
 %%              ERL_CFLAGS  - default -I paths for erts and ei
-%%              ERL_LDFLAGS - default -L and -lerl_interface -lei
+%%              ERL_LDFLAGS - default -L and [-lerl_interface (when opt_release < 23)] -lei
 %%              DRV_CFLAGS  - flags that will be used for compiling
 %%              DRV_LDFLAGS - flags that will be used for linking
 %%              EXE_CFLAGS  - flags that will be used for compiling

--- a/src/pc_port_env.erl
+++ b/src/pc_port_env.erl
@@ -194,6 +194,15 @@ erl_interface_dir(Subdir) ->
         Dir -> Dir
     end.
 
+has_erl_interface() ->
+  list_to_integer(erlang:system_info(otp_release)) < 23.
+
+maybe_link_erl_interface() ->
+  case  has_erl_interface() of
+    true -> "-lerl_interface";
+    false -> ""
+  end.
+
 erts_dir() ->
     lists:concat([code:root_dir(), "/erts-", erlang:system_info(version)]).
 
@@ -241,7 +250,7 @@ default_env() ->
                        "\" "
                       ])},
      {"ERL_EI_LIBDIR", lists:concat(["\"", erl_interface_dir(lib), "\""])},
-     {"ERL_LDFLAGS"  , " -L$ERL_EI_LIBDIR -lerl_interface -lei"},
+     {"ERL_LDFLAGS"  , " -L$ERL_EI_LIBDIR " ++ maybe_link_erl_interface() ++ " -lei"},
      {"ERLANG_ARCH"  , rebar_api:wordsize()},
      {"ERLANG_TARGET", rebar_api:get_arch()},
 


### PR DESCRIPTION
erl_interface is deprecated since 22, and removed in 23