### PR TITLE
Avoid erl_interface lib if nonexistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ BELOW HERE BE DRAGONS
 %% * port_env - Erlang list of key/value pairs which will control
 %%              the environment when running the compiler and linker.
 %%              Variables set in the surrounding system shell are taken
-%%              into consideration when expanding port_env.
+%%              into consideration when expanding port_env. Note that
+%%              for ERL_LDFLAGS, -lerl_interface is used for only those
+%%              Erlang/OTP versions where it exists (those prior to
+%%              version 23.0).
 %%
 %%              By default, the following variables are defined:
 %%              CC       - C compiler


### PR DESCRIPTION
The erl_interface C header and library were deprecated in Erlang/OTP
22 for removal in Erlang/OTP 23. Change the default C include paths
and linker options to not use erl_interface header files or libraries
if erl_interface.h is not detected in the erl_interface installation.

Change README.md to note that the erl_interface library is not always
used in ERL_LDFLAGS.