### PR TITLE
add openbsd support

### DIFF
--- a/src/pc_port_env.erl
+++ b/src/pc_port_env.erl
@@ -303,7 +303,16 @@ default_env() ->
       lists:concat([" /LIBPATH:$ERL_EI_LIBDIR "] ++
                     [EiLib++".lib " || EiLib <- ErlInterfaceLibs])},
      {"win32", "DRV_CFLAGS", "/Zi /Wall $ERL_CFLAGS"},
-     {"win32", "DRV_LDFLAGS", "/DLL $ERL_LDFLAGS"}
+     {"win32", "DRV_LDFLAGS", "/DLL $ERL_LDFLAGS"},
+
+     {"openbsd", "CC", "cc"},
+     {"openbsd", "CXX", "c++"},
+     {"openbsd", "AR", "ar"},
+     {"openbsd", "AS", "as"},
+     {"openbsd", "CPP", "cpp"},
+     {"openbsd", "LD", "ld"},
+     {"openbsd", "STRIP", "strip"},
+     {"openbsd", "NM", "nm"}
     ].
 
 get_tool(Arch, Tool, Default) ->


### PR DESCRIPTION
Hi,

I added OpenBSD support, setting `CXX` variable to `c++` which is the default compiler on OpenBSD (using clang/llvm). Other variables seems to be okay on my side, but, could you tell me if I missed something, another part of the code to modify to offer a full OpenBSD supports?

