### PR TITLE
Fix windows builds with msys2

### DIFF
--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -176,12 +176,11 @@ get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
             false -> cc
         end,
     Target1 = filename:join(ProjectRoot, Target),
-    ObjectFiles = [pc_util:replace_extension(O, ".o") || O <- SourceFiles],
     #spec{type      = pc_util:target_type(Target1),
           target    = coerce_extension(OsType, Target1),
           link_lang = LinkLang,
           sources   = SourceFiles,
-          objects   = ObjectFiles,
+          objects   = port_objects(SourceFiles),
           opts      = [port_opt(Config, O) || O <- fill_in_defaults(Opts)]}.
 
 expand_env(Source, Env) ->


### PR DESCRIPTION
Building on windows using msys2 fails without this patch, as the gcc output is renamed to ".obj" but the linker input still uses ".o"
I'm building on windows using msys2 with environment variables: REBAR_TARGET_ARCH_WORDSIZE=64 REBAR_TARGET_ARCH=x86_64-w64-mingw32

From looking at the code it looks like this transformation was just forgotten.