### PR TITLE
Fix for re:replace which crashes when gets unicode input without unicode flag 

### DIFF
--- a/src/pc_compilation.erl
+++ b/src/pc_compilation.erl
@@ -195,7 +195,7 @@ exec_compiler(_Config, Source, Cmd, ShOpts) ->
             AbsSource = filename:absname(Source),
             rebar_api:info("Compiling ~ts", [AbsSource]),
             Error = re:replace(RawError, Source, AbsSource,
-                               [{return, list}, global]),
+                               [{return, list}, global, unicode]),
             rebar_api:error("~ts", [Error]),
             rebar_api:abort();
         {ok, Output} ->


### PR DESCRIPTION
In my case this smal change fixed this https://github.com/blt/port_compiler/issues/70 issue. 