### PR TITLE
Honor REBAR_BARE_COMPILER_OUTPUT_DIR environment variable

### DIFF
--- a/src/pc_port_specs.erl
+++ b/src/pc_port_specs.erl
@@ -187,7 +187,7 @@ get_port_spec(Config, OsType, {_Arch, Target, Sources, Opts}) ->
             undefined ->
                 filename:join(ProjectRoot, Target);
             Dir -> 
-                filename:join([ProjectRoot, Dir, Target])
+                filename:join([Dir, Target])
         end,
     #spec{type      = pc_util:target_type(Target1),
           target    = coerce_extension(OsType, Target1),


### PR DESCRIPTION
In the case mix is calling out to rebar3's bare compiler it expects all artfiacts
to be written to the REBAR_BARE_COMPILER_OUTPUT_DIR.