### PR TITLE
Drop "-g" debug flag to reduce NIF .so size

### DIFF
--- a/src/pc_port_env.erl
+++ b/src/pc_port_env.erl
@@ -235,9 +235,9 @@ default_env() ->
       "$CC $PORT_IN_FILES $LDFLAGS $EXE_LDFLAGS -o $PORT_OUT_FILE"},
      {"EXE_LINK_CXX_TEMPLATE",
       "$CXX $PORT_IN_FILES $LDFLAGS $EXE_LDFLAGS -o $PORT_OUT_FILE"},
-     {"DRV_CFLAGS" , "-g -Wall -fPIC -MMD $ERL_CFLAGS"},
+     {"DRV_CFLAGS" , "-Wall -fPIC -MMD $ERL_CFLAGS"},
      {"DRV_LDFLAGS", "-shared $ERL_LDFLAGS"},
-     {"EXE_CFLAGS" , "-g -Wall -fPIC -MMD $ERL_CFLAGS"},
+     {"EXE_CFLAGS" , "-Wall -fPIC -MMD $ERL_CFLAGS"},
      {"EXE_LDFLAGS", "$ERL_LDFLAGS"},
 
      {"ERL_CFLAGS", lists:concat(


### PR DESCRIPTION
Hi @tsloughter 

This PR related to the issue described [here](https://github.com/blt/port_compiler/issues/83).

The idea is to reduce NIF `.so` size as shown below:
```bash
# with "-g"
priv/cuckoo_hash.so -> 6.8M

# without "-g"
priv/cuckoo_hash.so -> 1.4M
```

If one wants to add debugging symbols, he/she can adapat `CFLAGS + LDFLAGS` in `rebar.config`.

Thanks
/Z